### PR TITLE
Fixed filenames in console exec

### DIFF
--- a/cake/console/cake.php
+++ b/cake/console/cake.php
@@ -250,12 +250,12 @@ class ShellDispatcher {
 
 		$includes = array(
 			CORE_PATH . 'cake' . DS . 'config' . DS . 'paths.php',
-			CORE_PATH . 'cake' . DS . 'libs' . DS . 'object.php',
+			CORE_PATH . 'cake' . DS . 'libs' . DS . 'cake_object.php',
 			CORE_PATH . 'cake' . DS . 'libs' . DS . 'inflector.php',
 			CORE_PATH . 'cake' . DS . 'libs' . DS . 'configure.php',
 			CORE_PATH . 'cake' . DS . 'libs' . DS . 'file.php',
 			CORE_PATH . 'cake' . DS . 'libs' . DS . 'cache.php',
-			CORE_PATH . 'cake' . DS . 'libs' . DS . 'string.php',
+			CORE_PATH . 'cake' . DS . 'libs' . DS . 'cake_string.php',
 			CORE_PATH . 'cake' . DS . 'libs' . DS . 'class_registry.php',
 			CORE_PATH . 'cake' . DS . 'console' . DS . 'error.php'
 		);


### PR DESCRIPTION
cake.php used to include old string.php and object.php files. I changed them into cake_string.php and cake_object.php.