### PR TITLE
save_handler not work for PHP7.2, Session storage in database or cache.

### DIFF
--- a/cake/libs/cake_session.php
+++ b/cake/libs/cake_session.php
@@ -761,7 +761,7 @@ class CakeSession extends CakeObject {
 		$expires = time() + Configure::read('Session.timeout') * Security::inactiveMins();
 		$model =& ClassRegistry::getObject('Session');
 		$return = $model->save(array($model->primaryKey => $id) + compact('data', 'expires'));
-		return $return;
+		return $return ? true : false;
 	}
 
 /**

--- a/cake/libs/cake_session.php
+++ b/cake/libs/cake_session.php
@@ -636,7 +636,7 @@ class CakeSession extends CakeObject {
 /**
  * Helper method to restart a session.
  *
- * @return void
+ * @return boolean
  * @access private
  */
 	function __regenerateId() {
@@ -667,15 +667,17 @@ class CakeSession extends CakeObject {
 				session_start();
 			}
 		}
+		return true;
 	}
 
 /**
  * Restarts this session.
  *
  * @access public
+ * @return boolean
  */
 	function renew() {
-		$this->__regenerateId();
+		return $this->__regenerateId();
 	}
 
 /**

--- a/cake/libs/cake_session.php
+++ b/cake/libs/cake_session.php
@@ -375,7 +375,7 @@ class CakeSession extends CakeObject {
 			return $result;
 		}
 		$this->__setError(2, "$name doesn't exist");
-		return null;
+		return "";
 	}
 
 /**
@@ -462,6 +462,7 @@ class CakeSession extends CakeObject {
 		$this->start();
 		$this->renew();
 		$this->_checkValid();
+        return true;
 	}
 
 /**

--- a/cake/libs/cake_session.php
+++ b/cake/libs/cake_session.php
@@ -509,7 +509,9 @@ class CakeSession extends CakeObject {
 					if ($iniSet) {
 						ini_set('session.use_trans_sid', 0);
 						ini_set('url_rewriter.tags', '');
-						ini_set('session.save_handler', 'user');
+						if (version_compare(PHP_VERSION, '7.2.0', '<')) {;
+							ini_set('session.save_handler', 'user');
+						}
 						ini_set('session.serialize_handler', 'php');
 						ini_set('session.use_cookies', 1);
 						ini_set('session.name', Configure::read('Session.cookie'));
@@ -545,7 +547,9 @@ class CakeSession extends CakeObject {
 					if ($iniSet) {
 						ini_set('session.use_trans_sid', 0);
 						ini_set('url_rewriter.tags', '');
-						ini_set('session.save_handler', 'user');
+						if (version_compare(PHP_VERSION, '7.2.0', '<')) {;
+							ini_set('session.save_handler', 'user');
+						}
 						ini_set('session.use_cookies', 1);
 						ini_set('session.name', Configure::read('Session.cookie'));
 						ini_set('session.cookie_lifetime', $this->cookieLifeTime);
@@ -736,7 +740,7 @@ class CakeSession extends CakeObject {
 		));
 
 		if (empty($row[$model->alias]['data'])) {
-			return false;
+			return '';
 		}
 
 		return $row[$model->alias]['data'];


### PR DESCRIPTION
https://github.com/littleant/cakephp-1.3.21/issues/5

first problem

```
Recoverable fatal error: ini_set() [function.ini-set]: Cannot set 'user' save handler by ini_set() or session_module_name() in /home/akiyan/ir/cake/libs/cake_session.php on line 512
```

after add version_compare, second problem. 

```
Warning: session_start() [function.session-start]: Failed to read session data: user (path: /var/lib/php/sessions) in /home/akiyan/ir/cake/libs/cake_session.php on line 591

Warning: session_start() [function.session-start]: Failed to read session data: user (path: /var/lib/php/sessions) in /home/akiyan/ir/cake/libs/cake_session.php on line 595

Warning: session_start() [function.session-start]: Failed to read session data: user (path: /var/lib/php/sessions) in /home/akiyan/ir/cake/libs/cake_session.php on line 595
```

fixed return empty string in no session data.