### PR TITLE
Fix JsHelper call__ function to dispatch methods

### DIFF
--- a/cake/libs/view/helpers/js.php
+++ b/cake/libs/view/helpers/js.php
@@ -138,7 +138,7 @@ class JsHelper extends AppHelper {
 					unset($params['buffer']);
 				}
 			}
-			$out = $this->{$this->__engineName}->dispatchMethod($this, $method, $params);
+			$out = $this->dispatchMethod($this->{$this->__engineName}, $method, $params);
 			if ($this->bufferScripts && $buffer && is_string($out)) {
 				$this->buffer($out);
 				return null;


### PR DESCRIPTION
- fix problems with JsHelper dispatching method calls to itself causing
infinite loop and eventually out-of-memory errors