### PR TITLE
fix return on referer

### DIFF
--- a/cake/libs/controller/controller.php
+++ b/cake/libs/controller/controller.php
@@ -924,10 +924,12 @@ class Controller extends CakeObject {
 		if (!empty($ref) && defined('FULL_BASE_URL')) {
 			$base = FULL_BASE_URL . $this->webroot;
 			if (strpos($ref, $base) === 0) {
-				$return =  substr($ref, strlen($base));
-				if (isset($return[0]) && $return[0] != '/') {
-					$return = '/'.$return;
-				}
+                $return =  substr($ref, strlen($base));
+                if (empty($return)) {
+                    $return = '/';
+                } else if (isset($return[0]) && $return[0] != '/') {
+                    $return = '/'.$return;
+                }
 				return $return;
 			} elseif (!$local) {
 				return $ref;

--- a/cake/libs/controller/controller.php
+++ b/cake/libs/controller/controller.php
@@ -924,12 +924,12 @@ class Controller extends CakeObject {
 		if (!empty($ref) && defined('FULL_BASE_URL')) {
 			$base = FULL_BASE_URL . $this->webroot;
 			if (strpos($ref, $base) === 0) {
-                $return =  substr($ref, strlen($base));
-                if (empty($return)) {
-                    $return = '/';
-                } else if (isset($return[0]) && $return[0] != '/') {
-                    $return = '/'.$return;
-                }
+				$return =  substr($ref, strlen($base));
+				if (empty($return)) {
+					$return = '/';
+				} else if (isset($return[0]) && $return[0] != '/') {
+					$return = '/'.$return;
+				}
 				return $return;
 			} elseif (!$local) {
 				return $ref;


### PR DESCRIPTION
On an old cake project we detected that the referer-method does not return `/` (as it was implemented). The method returned an empty string, which leads to problems when calling the redirect function. This little change, fixes the problem. 