### PR TITLE
Backport some production fixes

### DIFF
--- a/cake/basics.php
+++ b/cake/basics.php
@@ -431,7 +431,10 @@ if (!function_exists('array_combine')) {
 			if (isset($_SERVER['HTTPS'])) {
 				return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
 			}
-			return (strpos(env('SCRIPT_URI'), 'https://') === 0);
+			if (env('SCRIPT_URI')) {
+				return (strpos(env('SCRIPT_URI'), 'https://') === 0);
+			}
+			return false;
 		}
 
 		if ($key == 'SCRIPT_NAME') {

--- a/cake/console/cake.php
+++ b/cake/console/cake.php
@@ -371,7 +371,7 @@ class ShellDispatcher {
 			$methods = array_diff(get_class_methods('Shell'), array('help'));
 		}
 		$methods = array_diff(get_class_methods($Shell), $methods);
-		$added = in_array(strtolower($arg), array_map('strtolower', $methods));
+		$added = $arg && in_array(strtolower($arg), array_map('strtolower', $methods));
 		$private = isset($arg[0]) && $arg[0] == '_' && method_exists($Shell, $arg);
 
 		if (!$private) {

--- a/cake/libs/cake_object.php
+++ b/cake/libs/cake_object.php
@@ -215,7 +215,7 @@ class CakeObject {
  * @access protected
  * @todo add examples to manual
  */
-	function _persist($name, $return = null, &$object, $type = null) {
+	function _persist($name, $return = null, &$object = null, $type = null) {
 		$file = CACHE . 'persistent' . DS . strtolower($name) . '.php';
 		if ($return === null) {
 			if (!file_exists($file)) {
@@ -225,7 +225,7 @@ class CakeObject {
 			}
 		}
 
-		if (!file_exists($file)) {
+		if (!file_exists($file) && $object !== null) {
 			$this->_savePersistent($name, $object);
 			return false;
 		} else {

--- a/cake/libs/cake_session.php
+++ b/cake/libs/cake_session.php
@@ -203,7 +203,7 @@ class CakeSession extends CakeObject {
 			}
 			$this->host = env('HTTP_HOST');
 
-			if (strpos($this->host, ':') !== false) {
+			if ($this->host && strpos($this->host, ':') !== false) {
 				$this->host = substr($this->host, 0, strpos($this->host, ':'));
 			}
 		}

--- a/cake/libs/controller/components/request_handler.php
+++ b/cake/libs/controller/components/request_handler.php
@@ -178,7 +178,7 @@ class RequestHandlerComponent extends CakeObject {
  *
  */
 	function __construct() {
-		$this->__acceptTypes = explode(',', env('HTTP_ACCEPT'));
+		$this->__acceptTypes = env('HTTP_ACCEPT') ? explode(',', env('HTTP_ACCEPT')) : array();
 		$this->__acceptTypes = array_map('trim', $this->__acceptTypes);
 
 		foreach ($this->__acceptTypes as $i => $type) {
@@ -398,7 +398,7 @@ class RequestHandlerComponent extends CakeObject {
  * @access public
  */
 	function isPut() {
-		return (strtolower(env('REQUEST_METHOD')) == 'put');
+		return env('REQUEST_METHOD') && (strtolower(env('REQUEST_METHOD')) == 'put');
 	}
 
 /**
@@ -408,7 +408,7 @@ class RequestHandlerComponent extends CakeObject {
  * @access public
  */
 	function isGet() {
-		return (strtolower(env('REQUEST_METHOD')) == 'get');
+		return env('REQUEST_METHOD') && (strtolower(env('REQUEST_METHOD')) == 'get');
 	}
 
 /**

--- a/cake/libs/controller/controller.php
+++ b/cake/libs/controller/controller.php
@@ -443,7 +443,7 @@ class Controller extends CakeObject {
 			}
 		}
 
-		if (class_exists($pluginController) && $pluginName != null) {
+		if ($pluginController && class_exists($pluginController) && $pluginName != null) {
 			$appVars = get_class_vars($pluginController);
 			$merge = array('components', 'helpers');
 

--- a/cake/libs/inflector.php
+++ b/cake/libs/inflector.php
@@ -518,7 +518,7 @@ class Inflector {
 	static function underscore($camelCasedWord) {
 		$_this =& Inflector::getInstance();
 		if (!($result = $_this->_cache(__FUNCTION__, $camelCasedWord))) {
-			$result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $camelCasedWord));
+			$result = strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', (string)$camelCasedWord));
 			$_this->_cache(__FUNCTION__, $camelCasedWord, $result);
 		}
 		return $result;
@@ -537,7 +537,7 @@ class Inflector {
 	static function humanize($lowerCaseAndUnderscoredWord) {
 		$_this =& Inflector::getInstance();
 		if (!($result = $_this->_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord))) {
-			$result = ucwords(str_replace('_', ' ', $lowerCaseAndUnderscoredWord));
+			$result = $lowerCaseAndUnderscoredWord ? ucwords(str_replace('_', ' ', $lowerCaseAndUnderscoredWord)) : '';
 			$_this->_cache(__FUNCTION__, $lowerCaseAndUnderscoredWord, $result);
 		}
 		return $result;

--- a/cake/libs/l10n.php
+++ b/cake/libs/l10n.php
@@ -413,7 +413,10 @@ class L10n extends CakeObject {
  * @access private
  */
 	function __autoLanguage() {
-		$_detectableLanguages = preg_split('/[,;]/', env('HTTP_ACCEPT_LANGUAGE'));
+		$_detectableLanguages = array();
+		if (env('HTTP_ACCEPT_LANGUAGE')) {
+			$_detectableLanguages = preg_split('/[,;]/', env('HTTP_ACCEPT_LANGUAGE'));
+		}
 		foreach ($_detectableLanguages as $key => $langKey) {
 			$langKey = strtolower($langKey);
 			if (strpos($langKey, '_') !== false) {

--- a/cake/libs/model/datasources/dbo/dbo_mysql.php
+++ b/cake/libs/model/datasources/dbo/dbo_mysql.php
@@ -121,7 +121,7 @@ class DboMysqlBase extends DboSource {
 		if ($cache != null) {
 			return $cache;
 		}
-		$fields = false;
+		$fields = array();
 		$cols = $this->query('SHOW FULL COLUMNS FROM ' . $this->fullTableName($model));
 
 		foreach ($cols as $column) {

--- a/cake/libs/model/datasources/dbo_source.php
+++ b/cake/libs/model/datasources/dbo_source.php
@@ -920,8 +920,9 @@ class DboSource extends DataSource {
  * @param integer $recursive Number of levels of association
  * @param array $stack
  */
-	function queryAssociation(&$model, &$linkModel, $type, $association, $assocData, &$queryData, $external = false, &$resultSet, $recursive, $stack) {
+	function queryAssociation(&$model, &$linkModel, $type, $association, $assocData, &$queryData, $external, &$resultSet, $recursive, $stack) {
 		if ($query = $this->generateAssociationQuery($model, $linkModel, $type, $association, $assocData, $queryData, $external, $resultSet)) {
+			$external = $external ?: false;
 			if (!isset($resultSet) || !is_array($resultSet)) {
 				if (Configure::read() > 0) {
 					echo '<div style = "font: Verdana bold 12px; color: #FF0000">' . sprintf(__('SQL Error in model %s:', true), $model->alias) . ' ';
@@ -1222,7 +1223,7 @@ class DboSource extends DataSource {
  * @return mixed
  * @access public
  */
-	function generateAssociationQuery(&$model, &$linkModel, $type, $association = null, $assocData = array(), &$queryData, $external = false, &$resultSet) {
+	function generateAssociationQuery(&$model, &$linkModel, $type, $association = null, $assocData = array(), &$queryData = null, $external = false, &$resultSet = null) {
 		$queryData = $this->__scrubQueryData($queryData);
 		$assocData = $this->__scrubQueryData($assocData);
 

--- a/cake/libs/model/model.php
+++ b/cake/libs/model/model.php
@@ -1377,7 +1377,7 @@ class Model extends Overloadable {
 			if (!empty($this->data)) {
 				$success = Set::merge($success, $this->data);
 			}
-			$this->data = false;
+			$this->data = array();
 			$this->_clearCache();
 			$this->validationErrors = array();
 		}


### PR DESCRIPTION
Backports some fixes I made on our internal 8.1 compatible cakephp core.

PHP8.1 has stricter checks on [passing null to non nullable internal functions](https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg)

PHP8.0 [deprecated nullable args before required ones](https://php.watch/versions/8.0/deprecate-required-param-after-optional)